### PR TITLE
Jekyll expects gems as an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then install the gem with Bundler
 Then add the gem to your Jekyll configuration.
 
     gems:
-      -octopress-image-tag
+      - octopress-image-tag
 
 ## Usage
 


### PR DESCRIPTION
Looks like more recent (?) versions of Jekyll expect `gems:` to be an array.

Using the previously specified syntax I get:

```
jekyll 3.0.1 | Error:  undefined method `each' for "-octopress-image-tag":String
```
